### PR TITLE
Org totals

### DIFF
--- a/assets/js/components/dashboard/DashboardIndex.jsx
+++ b/assets/js/components/dashboard/DashboardIndex.jsx
@@ -246,7 +246,7 @@ export default (props) => {
                 >
                   <Text style={{ ...styles.numberCount, color: primaryBlue }}>
                     {numeral(
-                      orgData && orgData.organization.total_packets_sent
+                      orgData && orgData.organization.total_packets
                     ).format("0,0")}
                   </Text>
                 </Row>
@@ -269,9 +269,9 @@ export default (props) => {
                   <Text
                     style={{ ...styles.numberCount, color: tertiaryPurple }}
                   >
-                    {numeral(
-                      orgData && orgData.organization.total_dc_used
-                    ).format("0,0")}
+                    {numeral(orgData && orgData.organization.total_dc).format(
+                      "0,0"
+                    )}
                   </Text>
                 </Row>
               </div>

--- a/assets/js/graphql/organizations.js
+++ b/assets/js/graphql/organizations.js
@@ -17,9 +17,9 @@ export const ORGANIZATION_SHOW = gql`
       port
       join_credentials
       multi_buy
-      total_packets_sent
-      total_dc_used
       dc_balance
+      total_dc
+      total_packets
     }
   }
 `;

--- a/lib/console/etl_error_worker.ex
+++ b/lib/console/etl_error_worker.ex
@@ -25,6 +25,8 @@ defmodule Console.EtlErrorWorker do
           org = Organizations.get_organization!(parsed_packet.organization_id)
           org_attrs = %{
             "dc_balance" => Enum.max([org.dc_balance - parsed_packet.dc_used, 0]),
+            "total_dc" => org.total_dc + packet["dc_used"],
+            "total_packets" => org.total_packets + 1
           }
           ConsoleWeb.Monitor.remove_from_packets_error_state()
 

--- a/lib/console/etl_worker.ex
+++ b/lib/console/etl_worker.ex
@@ -35,6 +35,8 @@ defmodule Console.EtlWorker do
               Enum.each(organizations_to_update, fn org ->
                 org_attrs = %{
                   "dc_balance" => Enum.max([org.dc_balance - organization_updates_map[org.id]["dc_used"], 0]),
+                  "total_dc" => org.total_dc + organization_updates_map[org.id]["dc_used"],
+                  "total_packets" => org.total_packets + length(parsed_packets)
                 }
                 
                 net_id_values = NetIds.get_all_for_organization(org.id) |> Enum.map(fn n -> n.value end)

--- a/lib/console/etl_worker.ex
+++ b/lib/console/etl_worker.ex
@@ -36,7 +36,7 @@ defmodule Console.EtlWorker do
                 org_attrs = %{
                   "dc_balance" => Enum.max([org.dc_balance - organization_updates_map[org.id]["dc_used"], 0]),
                   "total_dc" => org.total_dc + organization_updates_map[org.id]["dc_used"],
-                  "total_packets" => org.total_packets + length(parsed_packets)
+                  "total_packets" => org.total_packets + organization_updates_map[org.id]["packets_sent"]
                 }
                 
                 net_id_values = NetIds.get_all_for_organization(org.id) |> Enum.map(fn n -> n.value end)
@@ -95,10 +95,12 @@ defmodule Console.EtlWorker do
             nil ->
               %{
                 "dc_used" => packet["dc_used"],
+                "packets_sent" => 1
               }
             _ ->
               %{
                 "dc_used" => packet["dc_used"] + acc[packet["organization_id"]]["dc_used"],
+                "packets_sent" => acc[packet["organization_id"]]["packets_sent"] + 1
               }
           end
 

--- a/lib/console/organizations/organization.ex
+++ b/lib/console/organizations/organization.ex
@@ -20,6 +20,8 @@ defmodule Console.Organizations.Organization do
     field :join_credentials, :string
     field :port, :integer
     field :multi_buy, :integer
+    field :total_dc, :integer
+    field :total_packets, :integer
 
     has_many :memberships, Console.Organizations.Membership, on_delete: :delete_all
     many_to_many :users, Console.Auth.User, join_through: "memberships"
@@ -65,7 +67,9 @@ defmodule Console.Organizations.Organization do
       :address,
       :port,
       :multi_buy,
-      :join_credentials
+      :join_credentials,
+      :total_dc,
+      :total_packets
     ])
   end
 

--- a/lib/console/organizations/organization_resolver.ex
+++ b/lib/console/organizations/organization_resolver.ex
@@ -22,18 +22,6 @@ defmodule Console.Organizations.OrganizationResolver do
   def find(%{id: id}, %{context: %{current_user: current_user}}) do
     organization = Organizations.get_organization!(current_user, id)
 
-    query = from p in Packet,
-      select: %{
-        total_dc_used: sum(p.dc_used),
-        total_packets_sent: count()
-      },
-      where: p.organization_id == ^id
-
-    result = Repo.one!(query)
-
-    organization =
-      Map.put(organization, :total_dc_used, result.total_dc_used)
-      |> Map.put(:total_packets_sent, result.total_packets_sent)
     {:ok, organization}
   end
 

--- a/lib/console/organizations/organizations.ex
+++ b/lib/console/organizations/organizations.ex
@@ -23,7 +23,10 @@ defmodule Console.Organizations do
     query = from o in Organization,
       join: m in Membership, on: m.organization_id == o.id,
       where: m.user_id == ^current_user.id,
-      select: %{id: o.id, name: o.name, role: m.role, dc_balance: o.dc_balance, inserted_at: o.inserted_at, active: o.active}
+      select: %{
+        id: o.id, name: o.name, role: m.role, dc_balance: o.dc_balance,
+        inserted_at: o.inserted_at, active: o.active, total_packets: o.total_packets,
+        total_dc: o.total_dc}
     Repo.all(query)
   end
 

--- a/lib/console_web/schema/schema.ex
+++ b/lib/console_web/schema/schema.ex
@@ -45,8 +45,8 @@ defmodule ConsoleWeb.Schema do
     field :port, :integer
     field :join_credentials, :string
     field :multi_buy, :integer
-    field :total_dc_used, :integer
-    field :total_packets_sent, :integer
+    field :total_dc, :integer
+    field :total_packets, :integer
   end
 
   object :api_key do

--- a/priv/repo/migrations/20220228221015_add_org_fields.exs
+++ b/priv/repo/migrations/20220228221015_add_org_fields.exs
@@ -1,0 +1,10 @@
+defmodule Console.Repo.Migrations.AddOrgFields do
+  use Ecto.Migration
+
+  def change do
+    alter table(:organizations) do
+      add :total_dc, :integer, null: false, default: 0
+      add :total_packets, :integer, null: false, default: 0
+    end
+  end
+end

--- a/priv/repo/migrations/20220228223911_populate_org_total_fields.exs
+++ b/priv/repo/migrations/20220228223911_populate_org_total_fields.exs
@@ -1,0 +1,18 @@
+defmodule Console.Repo.Migrations.PopulateOrgTotalFields do
+  use Ecto.Migration
+
+  def up do
+    results = Ecto.Adapters.SQL.query!(Console.Repo, """
+      SELECT sum(dc_used), count(*), organization_id FROM packets GROUP BY organization_id;
+    """, [], timeout: :infinity).rows
+
+    Enum.each(results, fn row ->
+      Ecto.Adapters.SQL.query!(Console.Repo, """
+        UPDATE organizations SET total_dc = $1, total_packets = $2 WHERE id = $3;
+      """, [Enum.at(row, 0), Enum.at(row, 1), Enum.at(row, 2)])
+    end)
+  end
+
+  def down do
+  end
+end


### PR DESCRIPTION
The query to count total number of packets sent and total number of DC used for each org was v expensive. This PR replaces that implementation by adding two fields that get updated as the packets come in.