### PR TITLE
Chart UX

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -480,3 +480,7 @@ a.version-link {
   border-left-color: black;
   padding-right: 10px;
 }
+
+.dashboard-packets-loading {
+  width: 100%;
+}

--- a/assets/js/components/dashboard/DashboardIndex.jsx
+++ b/assets/js/components/dashboard/DashboardIndex.jsx
@@ -6,7 +6,7 @@ import DashboardLayout from "../common/DashboardLayout";
 import { ORGANIZATION_SHOW } from "../../graphql/organizations";
 import { GET_ORGANIZATION_PACKETS } from "../../graphql/packets";
 import analyticsLogger from "../../util/analyticsLogger";
-import { Typography, Card, Row, Col, Button, Tooltip } from "antd";
+import { Typography, Card, Row, Col, Button, Tooltip, Spin } from "antd";
 const { Text } = Typography;
 import { primaryBlue, tertiaryPurple } from "../../util/colors";
 import { Bar } from "react-chartjs-2";
@@ -159,7 +159,26 @@ export default (props) => {
   }, []);
 
   const renderChart = () => {
-    if (packetsData) {
+    if (packetsLoading) {
+      const labels = range(24, 0).map((index) => {
+        return 0;
+      });
+
+      const chartData = {
+        labels,
+        datasets: [
+          {
+            data: [],
+            backgroundColor: "#ACB9CD",
+          },
+        ],
+      };
+      return (
+        <Spin wrapperClassName="dashboard-packets-loading" tip="Loading...">
+          <Bar data={chartData} options={chartOptions} height={300} />
+        </Spin>
+      );
+    } else if (packetsData) {
       const packetsMap = JSON.parse(packetsData.packets.packets_per_hour);
 
       const data = range(24, 0).map((index) => {
@@ -191,9 +210,14 @@ export default (props) => {
         ],
       };
 
-      return <Bar data={chartData} options={chartOptions} height={250} />;
+      return <Bar data={chartData} options={chartOptions} height={300} />;
+    } else if (packetsError) {
+      return (
+        <div style={{ padding: 40, margin: "auto" }}>
+          <Text>Data failed to load, please reload the page and try again</Text>
+        </div>
+      );
     }
-    return <div />;
   };
 
   return (


### PR DESCRIPTION
When data loads:
<img width="1470" alt="Screen Shot 2022-03-01 at 12 49 07 PM" src="https://user-images.githubusercontent.com/51131939/156238725-ecc71dd3-226e-45e1-b8b4-662494231e1b.png">

When data is loading:
<img width="1475" alt="Screen Shot 2022-03-01 at 12 49 23 PM" src="https://user-images.githubusercontent.com/51131939/156238735-a99b97bd-2c50-4a2e-b104-fe9ffa8a5db4.png">

When data fails to load:
<img width="1460" alt="Screen Shot 2022-03-01 at 12 50 49 PM" src="https://user-images.githubusercontent.com/51131939/156238744-6fb7505b-0185-4d74-a21f-a6fbdb8643e9.png">

