### PR TITLE
Repopulate Org DC and Packets Totals

### DIFF
--- a/priv/repo/migrations/20220302192749_repopulate_org_totals.exs
+++ b/priv/repo/migrations/20220302192749_repopulate_org_totals.exs
@@ -1,0 +1,19 @@
+defmodule Console.Repo.Migrations.RepopulateOrgTotals do
+  use Ecto.Migration
+
+  # Repopulating after bug was fixed that made these numbers out of sync
+  def up do
+    results = Ecto.Adapters.SQL.query!(Console.Repo, """
+      SELECT sum(dc_used), count(*), organization_id FROM packets GROUP BY organization_id;
+    """, [], timeout: :infinity).rows
+
+    Enum.each(results, fn row ->
+      Ecto.Adapters.SQL.query!(Console.Repo, """
+        UPDATE organizations SET total_dc = $1, total_packets = $2 WHERE id = $3;
+      """, [Enum.at(row, 0), Enum.at(row, 1), Enum.at(row, 2)])
+    end)
+  end
+
+  def down do
+  end
+end


### PR DESCRIPTION
A bug was [fixed](https://github.com/helium/roaming-console/commit/cb9e9643b442b90070d7fbc8cc756d908122bd49) yesterday that was causing some packets to not get processed in the ETL error worker and thus made the total DC and packets for orgs become out of sync if a packet errored in the queue. This PR will repopulate the numbers so that they are in sync again by rerunning the migration to do so.

⚠️  **This will require maintenance time for both servers.**