### PR TITLE
Fix packets view

### DIFF
--- a/priv/repo/migrations/20220309003524_update_mat_view_inclusive_date_range.exs
+++ b/priv/repo/migrations/20220309003524_update_mat_view_inclusive_date_range.exs
@@ -1,0 +1,29 @@
+defmodule Console.Repo.Migrations.UpdateMatViewInclusiveDateRange do
+  use Ecto.Migration
+
+  def up do
+    execute """
+    DROP MATERIALIZED VIEW packets_view;
+    CREATE MATERIALIZED VIEW packets_view AS
+      SELECT stats30d.organization_id, packets_30d, dc_30d from
+      (
+        SELECT organization_id, COUNT(id) AS packets_30d, SUM(dc_used) AS dc_30d FROM packets
+        WHERE reported_at_epoch >= CAST(EXTRACT(epoch FROM NOW()) * 1000 - 2592000000 AS BIGINT) AND reported_at_epoch <= CAST(EXTRACT(epoch FROM NOW()) * 1000 - 86400000 AS BIGINT) GROUP BY organization_id
+      ) stats30d
+    ;
+    """
+  end
+
+  def down do
+    execute """
+    DROP MATERIALIZED VIEW packets_view;
+    CREATE MATERIALIZED VIEW packets_view AS
+      SELECT stats30d.organization_id, packets_30d, dc_30d from
+      (
+        SELECT organization_id, COUNT(id) AS packets_30d, SUM(dc_used) AS dc_30d FROM packets
+        WHERE reported_at_epoch > CAST(EXTRACT(epoch FROM NOW()) * 1000 - 2592000000 AS BIGINT) AND reported_at_epoch < CAST(EXTRACT(epoch FROM NOW()) * 1000 - 86400000 AS BIGINT) GROUP BY organization_id
+      ) stats30d
+    ;
+    """
+  end
+end


### PR DESCRIPTION
This PR updates the view to INCLUDE the limit values into the results for the count for 30d.

`>` -> `>=`
`<` -> `<=`