### PR TITLE
Multiple fixes (outlined below)

### DIFF
--- a/assets/js/components/common/TopBar.jsx
+++ b/assets/js/components/common/TopBar.jsx
@@ -93,7 +93,7 @@ class TopBar extends Component {
           <Text style={{ color: "white", fontWeight: 600 }}>Net IDs: </Text>
           {sortBy(organization?.net_ids, ["value"]).map((net_id) => (
             <Tag
-              key={`badge-${net_id}`}
+              key={`badge-${net_id.value}`}
               color="#393F45"
               style={{ color: "#8C8C8C", margin: 0 }}
             >

--- a/assets/js/components/configuration/ConfigForm.jsx
+++ b/assets/js/components/configuration/ConfigForm.jsx
@@ -53,6 +53,10 @@ export default ({ data, submit, otherNetIds }) => {
     if (fieldName === "protocol") {
       const value = changedValues[fieldName];
       setProtocol(value);
+
+      if (value === "http" && config.protocol === "udp") {
+        form.setFieldsValue({ http_dedupe_timeout: 200 });
+      }
     }
   };
 
@@ -284,7 +288,6 @@ export default ({ data, submit, otherNetIds }) => {
                   <InputNumber
                     style={{ width: "100%" }}
                     disabled={!userCan({ role: currentRole })}
-                    defaultValue={200}
                   />
                 </Form.Item>
               </>

--- a/assets/js/components/configuration/ConfigurationIndex.jsx
+++ b/assets/js/components/configuration/ConfigurationIndex.jsx
@@ -18,7 +18,7 @@ export default (props) => {
     (state) => state.organization.currentOrganizationId
   );
 
-  const { data, refetch: orgRefetch } = useQuery(ALL_NET_IDS, {
+  const { data, refetch } = useQuery(ALL_NET_IDS, {
     fetchPolicy: "cache-first",
   });
 
@@ -29,7 +29,7 @@ export default (props) => {
     channel.on(
       `graphql:configuration_index:${currentOrganizationId}:settings_update`,
       (_message) => {
-        orgRefetch();
+        refetch();
       }
     );
 
@@ -58,34 +58,35 @@ export default (props) => {
           boxShadow: "0px 20px 20px -7px rgba(17, 24, 31, 0.19)",
         }}
       >
-        <Tabs defaultActiveKey={(netIds[0] && netIds[0].value) || null}>
-          {netIds.map((n) => {
-            return (
-              <TabPane tab={`Net ID ${decimalToHex(n.value)}`} key={n.value}>
-                <div style={{ justifyContent: "flex-end", display: "flex" }}>
-                  <UserCan noManager>
-                    <Text className="config-label">Active:</Text>
-                    <Switch
-                      checked={n.active}
-                      onChange={(active) => updateNetIdActive(n.id, active)}
-                      style={{ marginLeft: 10 }}
-                    />
-                  </UserCan>
-                </div>
-                <Divider />
-                <ConfigForm
-                  data={n}
-                  key={n.value}
-                  submit={submit}
-                  otherNetIds={netIds.filter((ni) => ni.id !== n.id)}
-                />
-              </TabPane>
-            );
-          })}
-          {netIds.length === 0 && (
-            <div>No Net ID has been linked to your Organization.</div>
-          )}
-        </Tabs>
+        {netIds.length > 0 ? (
+          <Tabs defaultActiveKey={(netIds[0] && netIds[0].value) || null}>
+            {netIds.map((n) => {
+              return (
+                <TabPane tab={`Net ID ${decimalToHex(n.value)}`} key={n.value}>
+                  <div style={{ justifyContent: "flex-end", display: "flex" }}>
+                    <UserCan noManager>
+                      <Text className="config-label">Active:</Text>
+                      <Switch
+                        checked={n.active}
+                        onChange={(active) => updateNetIdActive(n.id, active)}
+                        style={{ marginLeft: 10 }}
+                      />
+                    </UserCan>
+                  </div>
+                  <Divider />
+                  <ConfigForm
+                    data={n}
+                    key={n.value}
+                    submit={submit}
+                    otherNetIds={netIds.filter((ni) => ni.id !== n.id)}
+                  />
+                </TabPane>
+              );
+            })}
+          </Tabs>
+        ) : (
+          <div>No Net ID has been linked to your Organization.</div>
+        )}
       </div>
     </DashboardLayout>
   );

--- a/lib/console/organizations/organizations.ex
+++ b/lib/console/organizations/organizations.ex
@@ -338,6 +338,15 @@ defmodule Console.Organizations do
               multi_buy: net_id.config["multi_buy"],
               active: net_id.active
             }
+          nil -> # no protocol config has been set yet
+            {
+              organization_id: org.id,
+              name: org.name,
+              net_id: net_id.value,
+              joins: net_id.config["join_credentials"],
+              multi_buy: net_id.config["multi_buy"],
+              active: net_id.active
+            }
         end
       end)
     end)

--- a/lib/console/organizations/organizations.ex
+++ b/lib/console/organizations/organizations.ex
@@ -339,7 +339,7 @@ defmodule Console.Organizations do
               active: net_id.active
             }
           nil -> # no protocol config has been set yet
-            {
+            %{
               organization_id: org.id,
               name: org.name,
               net_id: net_id.value,

--- a/lib/console/organizations/organizations.ex
+++ b/lib/console/organizations/organizations.ex
@@ -343,7 +343,7 @@ defmodule Console.Organizations do
               organization_id: org.id,
               name: org.name,
               net_id: net_id.value,
-              joins: net_id.config["join_credentials"],
+              joins: net_id.config["join_credentials"] || [],
               multi_buy: net_id.config["multi_buy"],
               active: net_id.active
             }

--- a/lib/console_web/controllers/data_credit_controller.ex
+++ b/lib/console_web/controllers/data_credit_controller.ex
@@ -432,7 +432,9 @@ defmodule ConsoleWeb.DataCreditController do
   def broadcast_packet_purchaser_refill_dc_balance(%Organization{} = organization) do
     if organization.dc_balance > 0 do
       NetIds.get_all_for_organization(organization.id) |> Enum.map(fn net_id ->
-        ConsoleWeb.Endpoint.broadcast("net_id:all", "net_id:all:keep_purchasing", %{ net_ids: [net_id.value]})
+        if net_id.active do
+          ConsoleWeb.Endpoint.broadcast("net_id:all", "net_id:all:keep_purchasing", %{ net_ids: [net_id.value]})
+        end
       end)
     end
   end


### PR DESCRIPTION
- Fix front end warnings by moving conditional `div` when no net IDs outside of `Tabs` component, which must have a `TabPane` child.
- Prevent broadcasting `keep_purchasing` for an inactive Net ID.
- Prevent error thrown when a Net ID with no protocol-specific config has been set.