### PR TITLE
Dedupe timeout required for http configs

### DIFF
--- a/assets/js/components/configuration/ConfigForm.jsx
+++ b/assets/js/components/configuration/ConfigForm.jsx
@@ -21,7 +21,6 @@ import {
   UploadOutlined,
   SaveOutlined,
   ClearOutlined,
-  CopyOutlined,
 } from "@ant-design/icons";
 
 export default ({ data, submit, netId }) => {
@@ -253,6 +252,20 @@ export default ({ data, submit, netId }) => {
                       Dedupe Timeout (in milliseconds)
                     </Text>
                   }
+                  rules={[
+                    {
+                      required: true,
+                      message: "Dedupe Timeout is required.",
+                    },
+                    {
+                      validator: (_, value) =>
+                        parseInt(value) >= 0 && Number.isInteger(value)
+                          ? Promise.resolve()
+                          : Promise.reject(
+                              "Dedupe timeout must be a positive whole number."
+                            ),
+                    },
+                  ]}
                 >
                   <InputNumber
                     style={{ width: "100%" }}

--- a/assets/js/components/configuration/ConfigForm.jsx
+++ b/assets/js/components/configuration/ConfigForm.jsx
@@ -259,10 +259,10 @@ export default ({ data, submit, netId }) => {
                     },
                     {
                       validator: (_, value) =>
-                        parseInt(value) >= 0 && Number.isInteger(value)
+                        Number.isInteger(value) && value >= 0
                           ? Promise.resolve()
                           : Promise.reject(
-                              "Dedupe timeout must be a positive whole number."
+                              "Dedupe Timeout must be a positive whole number."
                             ),
                     },
                   ]}

--- a/lib/console_web/controllers/net_id_controller.ex
+++ b/lib/console_web/controllers/net_id_controller.ex
@@ -89,7 +89,7 @@ defmodule ConsoleWeb.NetIdController do
     _organization = Organizations.get_organization!(conn.assigns.current_user, net_id.organization_id)
 
     config = Enum.filter(net_id.config, fn c -> c["config_id"] != config_id end)
-    http_headers = Enum.filter(net_id.http_headers, fn c -> elem(c, 0) != config_id end) |> Map.new()
+    http_headers = Enum.filter(net_id.http_headers || %{}, fn c -> elem(c, 0) != config_id end) |> Map.new()
     http_headers = case length(Map.keys(%{})) do
       0 -> nil
       _ -> http_headers

--- a/test/console_web/controllers/net_id_controller_test.exs
+++ b/test/console_web/controllers/net_id_controller_test.exs
@@ -45,6 +45,9 @@ defmodule ConsoleWeb.NetIdControllerTest do
       assert response(resp_conn, 422) # invalid http_flow_type, should not update
 
       resp_conn = put conn, net_id_path(conn, :update, net_id.id), %{ "config_id" => "id_1", "protocol" => "http", "http_endpoint" => "hello.com", "http_flow_type" => "async" }
+      assert response(resp_conn, 422) # missing http_dedupe_timeout, should not update
+      
+      resp_conn = put conn, net_id_path(conn, :update, net_id.id), %{ "config_id" => "id_1", "protocol" => "http", "http_endpoint" => "hello.com", "http_flow_type" => "async", "http_dedupe_timeout" => 200}
       assert response(resp_conn, 204) # valid http config, should update
 
       net_id = NetIds.get_net_id(123)


### PR DESCRIPTION
```
➜  roaming-console git:(requireDedupe) mix test

17:59:08.382 [info]  Migrations already up
..................

Finished in 1.1 seconds (0.2s async, 0.8s sync)
18 tests, 0 failures
```