### PR TITLE
Send all net_ids when broadcasting stop/keep purchasing

### DIFF
--- a/lib/console/etl_error_worker.ex
+++ b/lib/console/etl_error_worker.ex
@@ -32,9 +32,10 @@ defmodule Console.EtlErrorWorker do
           with {:ok, updated_org} <- Organizations.update_organization!(org, org_attrs) do
             ConsoleWeb.Monitor.remove_from_packets_error_state()
             if org.dc_balance - parsed_packet.dc_used <= 0 do
-              NetIds.get_all_for_organization(org.id) |> Enum.map(fn net_id ->
-                ConsoleWeb.Endpoint.broadcast("net_id:all", "net_id:all:stop_purchasing", %{ net_ids: [net_id.value]})
+              net_id_values = NetIds.get_all_for_organization(org.id) |> Enum.map(fn net_id ->
+                net_id.value
               end)
+              ConsoleWeb.Endpoint.broadcast("net_id:all", "net_id:all:stop_purchasing", %{ net_ids: net_id_values })
             end
             ConsoleWeb.DataCreditController.check_org_dc_balance(updated_org, org.dc_balance)
           end

--- a/lib/console/etl_worker.ex
+++ b/lib/console/etl_worker.ex
@@ -40,9 +40,10 @@ defmodule Console.EtlWorker do
                 }
 
                 if org.dc_balance - organization_updates_map[org.id]["dc_used"] <= 0 do
-                  NetIds.get_all_for_organization(org.id) |> Enum.map(fn net_id ->
-                    ConsoleWeb.Endpoint.broadcast("net_id:all", "net_id:all:stop_purchasing", %{ net_ids: [net_id.value]})
+                  net_id_values = NetIds.get_all_for_organization(org.id) |> Enum.map(fn net_id ->
+                    net_id.value
                   end)
+                  ConsoleWeb.Endpoint.broadcast("net_id:all", "net_id:all:stop_purchasing", %{ net_ids: net_id_values })
                 end
 
                 Organizations.update_organization!(org, org_attrs)

--- a/lib/console_web/controllers/data_credit_controller.ex
+++ b/lib/console_web/controllers/data_credit_controller.ex
@@ -431,11 +431,10 @@ defmodule ConsoleWeb.DataCreditController do
 
   def broadcast_packet_purchaser_refill_dc_balance(%Organization{} = organization) do
     if organization.dc_balance > 0 do
-      NetIds.get_all_for_organization(organization.id) |> Enum.map(fn net_id ->
-        if net_id.active do
-          ConsoleWeb.Endpoint.broadcast("net_id:all", "net_id:all:keep_purchasing", %{ net_ids: [net_id.value]})
-        end
+      net_id_values = NetIds.get_all_for_organization(organization.id) |> Enum.map(fn net_id ->
+        net_id.value
       end)
+      ConsoleWeb.Endpoint.broadcast("net_id:all", "net_id:all:keep_purchasing", %{ net_ids: net_id_values})
     end
   end
 end


### PR DESCRIPTION
Since PP is aware of which configs are active/inactive, simply send net ID values for stop/keep purchasing. The actual change will only apply to those with active configs (on PP's side).